### PR TITLE
Adding password support to 'start_redis'

### DIFF
--- a/lib/fluent/plugin_mixin/redis.rb
+++ b/lib/fluent/plugin_mixin/redis.rb
@@ -48,6 +48,7 @@ module Fluent
           :host => @host,
           :port => @port,
           :driver => @driver,
+          :password => @password,
           :thread_safe => true
         )
       end


### PR DESCRIPTION
Enabling start_redis to connect to a redis with password.
